### PR TITLE
Migrate prototype construction to static new() methods

### DIFF
--- a/IndexedDB/IndexedQueryCompiler.js
+++ b/IndexedDB/IndexedQueryCompiler.js
@@ -53,10 +53,12 @@ const IndexedQueryCompiler = {
      *
      * @return {undefined}
      */
-    _make(storeName, db) {
-        this._allQueries = [];
-        this._store = storeName;
-        this._db = db;
+    new(storeName, db) {
+        const _allQueries = [];
+        const _store = storeName;
+        const _db = db;
+
+        return { _allQueries, _store, _db, __proto__: this };
     },
 
     /**

--- a/IndexedDB/index.js
+++ b/IndexedDB/index.js
@@ -6,9 +6,11 @@ const IndexedStoreDefinition = {
     name: '',
     indexes: null,
 
-    _make(info) {
-        this.description = info;
-        this.indexes = [];
+    new(info) {
+        const description = info;
+        const indexes = [];
+
+        return { description, indexes, __proto__: this };
     }
 };
 
@@ -38,11 +40,13 @@ const IndexedDefinition = {
      *
      * @param  {number} version
      *
-     * @return {undefined}
+     * @return {IndexedDefinition}
      */
-    _make(version) {
-        this._version = version;
-        this._allStores = [];
+    new(version) {
+        const _version = version;
+        const _allStores = [];
+
+        return { _version, _allStores, __proto__: this };
     },
 
     /**
@@ -177,20 +181,12 @@ const IndexedDB = {
      *
      * @param {string} name of the db to open
      */
-    constructor(name) {
-        this._name = name;
-        this._definitions = [];
+    new(name) {
+        const _name = name;
+        const _definitions = [];
+        const _promise = async(this._setup.bind(this));
 
-        this._promise = async(this._setup.bind(this));
-
-        return this;
-    },
-
-    /**
-     * @deprecated
-     */
-    _make(...args) {
-        return this.constructor(...args);
+        return { _name, _definitions, _promise, __proto__: this };
     },
 
     /**

--- a/core/Application.js
+++ b/core/Application.js
@@ -25,22 +25,8 @@ const Application = {
      *
      * @return {Application}
      */
-    constructor() {
-        super.constructor();
-
-        return this;
-    },
-
-    /**
-     * @deprecated Do not use any more.
-     * @see Application.constructor
-     *
-     * @param  {any[]} args {@link Application.constructor}
-     *
-     * @return {Application} the current instance
-     */
-    _make(...args) {
-        return this.constructor(...args);
+    new() {
+        return { __proto__: this };
     },
 
     /**

--- a/core/DataStorage.js
+++ b/core/DataStorage.js
@@ -87,15 +87,15 @@ const DataStorage = {
     /**
      * @return {DataStorage}
      */
-    constructor() {
-        super.constructor();
+    new() {
+        const instance = super.new();
 
-        this.when = whenFilled(this);
-        this.whenNext = whenNext(this);
-        this.once = once(this);
-        this._filledCallbacks = [];
+        instance.when = whenFilled(instance);
+        instance.whenNext = whenNext(instance);
+        instance.once = once(instance);
+        instance._filledCallbacks = [];
 
-        return this;
+        return instance;
     },
 
     /**

--- a/core/EventTarget.js
+++ b/core/EventTarget.js
@@ -11,19 +11,10 @@ const EventTarget = {
     /**
      * @return {EventTarget}
      */
-    constructor() {
-        this._listeners = {};
+    new() {
+        const _listeners = {};
 
-        return this;
-    },
-
-    /**
-     * @deprecated Do not use the make constructors
-     *
-     * @return {this}      [description]
-     */
-    _make(...args) {
-        return this.constructor(...args);
+        return { _listeners, __proto__: this };
     },
 
     /**

--- a/core/InjectionReceiver.js
+++ b/core/InjectionReceiver.js
@@ -13,10 +13,10 @@ const InjectionReceiver = {
     /**
      * @return {InjectionReceiver}
      */
-    constructor() {
-        this._injectedObjects = new WeakMap();
+    new() {
+        const _injectedObjects = new WeakMap();
 
-        return this;
+        return { _injectedObjects, __proto__: this };
     },
 
     /**

--- a/core/NetworkRequest.js
+++ b/core/NetworkRequest.js
@@ -84,25 +84,11 @@ const NetworkRequest = {
      *
      * @return {NetworkRequest} the request it self
      */
-    constructor(url, { method = 'GET', type = 'none' } = {}) {
-        this.type = type;
-        this.method = method;
-        this._headers = {};
-        this.url = url;
-        this._listeners = [];
+    new(url, { method = 'GET', type = 'none' } = {}) {
+        const _headers = {};
+        const _listeners = [];
 
-        return this;
-    },
-
-    /**
-     * [_make description]
-     *
-     * @deprecated use the constructor
-     * @param  {array} args [description]
-     * @return {void}      [description]
-     */
-    _make(...args) {
-        return this.constructor(...args);
+        return { method, type, _headers, _listeners, __proto__: this };
     },
 
     /**


### PR DESCRIPTION
Inspired by Rust we want to migrate all Prototypes from `constructor()` methods to static `new()` methods. this will eliminate the required use of `Object.create(...)`.