### PR TITLE
Revert "Bump eslint-plugin-jsdoc from 38.1.6 to 39.0.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2758,9 +2758,9 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "39.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.0.1.tgz",
-      "integrity": "sha512-lNPnz5DlmLekkrVFM66TE5VQwceDu420tWW4CNYc/BMoKDJuvTTzmu/djK75lr9d8PLVoPDnyexVV7Pp59rOKg==",
+      "version": "38.1.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-38.1.6.tgz",
+      "integrity": "sha512-n4s95oYlg0L43Bs8C0dkzIldxYf8pLCutC/tCbjIdF7VDiobuzPI+HZn9Q0BvgOvgPNgh5n7CSStql25HUG4Tw==",
       "dev": true,
       "requires": {
         "@es-joy/jsdoccomment": "~0.22.1",
@@ -2768,7 +2768,8 @@
         "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
         "esquery": "^1.4.0",
-        "semver": "^7.3.6",
+        "regextras": "^0.8.0",
+        "semver": "^7.3.5",
         "spdx-expression-parse": "^3.0.1"
       },
       "dependencies": {
@@ -2787,19 +2788,13 @@
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true
         },
-        "lru-cache": {
-          "version": "7.8.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.0.tgz",
-          "integrity": "sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg==",
-          "dev": true
-        },
         "semver": {
-          "version": "7.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-          "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
-            "lru-cache": "^7.4.0"
+            "lru-cache": "^6.0.0"
           }
         }
       }
@@ -6159,6 +6154,12 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true
+    },
+    "regextras": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
+      "integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
       "dev": true
     },
     "release-zalgo": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "coveralls": "^3.1.0",
     "eslint": "^7.7.0",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jsdoc": "^39.0.1",
+    "eslint-plugin-jsdoc": "^38.0.3",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "gulp-clean": "^0.4.0",


### PR DESCRIPTION
Reverts TitanNanoDE/ApplicationFrame#288 because it seems to have broken something and didn't get covered by Travis.